### PR TITLE
Map created_by existing user inside Joomla4

### DIFF
--- a/components/com_storychief/helpers/story.php
+++ b/components/com_storychief/helpers/story.php
@@ -229,6 +229,26 @@ class StoryHelper
         $article['metadata'] = json_encode($metaData);
         $article['images'] = json_encode($imageData);
 
+        if (isset($this->data['author']['data']['email'])) {
+            $db = Factory::getDbo();
+            $query = $db->getQuery(true);
+
+            $constraints = [
+                $db->quoteName('email').' = '.$db->quote($this->data['author']['data']['email']),
+            ];
+
+            $query
+                ->select($db->quoteName('id'))
+                ->from($db->quoteName('#__users'))
+                ->where($constraints)
+                ->setLimit(1);
+
+            if (($userId = $db->setQuery($query)->loadResult())) {
+                $article['created_by'] = $userId;
+                $article['created_by_alias'] = null;
+            }
+        }
+
         if (isset($this->data['tags']['data']) && !empty($this->data['tags']['data'])) {
             foreach ($this->data['tags']['data'] as $tag) {
                 $db = Factory::getDbo();


### PR DESCRIPTION
## Description

Currently the user from StoryChief is mapped as an alias.

![Screenshot 2022-07-29 at 12 15 22](https://user-images.githubusercontent.com/4041473/181738172-9514765b-1544-444c-ac2f-b6bd733c6f37.png)

With these changes the plugin will do a look-up if the email address exists as a real user. And use the user ID instead of setting an alias.

![Screenshot 2022-07-29 at 12 16 58](https://user-images.githubusercontent.com/4041473/181738641-5fc44932-fa51-4cbf-8e3b-c99f762f0d9b.png)
